### PR TITLE
33 - FRFundsConfirmationResponse and test data factories

### DIFF
--- a/securebanking-openbanking-uk-bom/pom.xml
+++ b/securebanking-openbanking-uk-bom/pom.xml
@@ -81,6 +81,13 @@
                 <type>test-jar</type>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>com.forgerock.securebanking</groupId>
+                <artifactId>securebanking-openbanking-uk-forgerock-datamodel</artifactId>
+                <version>${securebanking-openbanking-forgerock-datamodel.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/securebanking-openbanking-uk-common/pom.xml
+++ b/securebanking-openbanking-uk-common/pom.xml
@@ -41,6 +41,14 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -54,5 +62,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <!-- Need to format and then check the license as when regenerated the new files will not have the
+                license headers in -->
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>format</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/securebanking-openbanking-uk-common/src/main/java/com/forgerock/securebanking/openbanking/uk/common/api/meta/OBVersion.java
+++ b/securebanking-openbanking-uk-common/src/main/java/com/forgerock/securebanking/openbanking/uk/common/api/meta/OBVersion.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.common.api.meta;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
+
+/**
+ * Represents the API versions on the OB sandbox.
+ */
+@Slf4j
+public enum OBVersion {
+    v1_1,
+    v2_0,
+    v3_0,
+    v3_1,
+    v3_1_1,
+    v3_1_2,
+    v3_1_3,
+    v3_1_4,
+    v3_1_5,
+    v3_1_6;
+
+    /**
+     * Provides the OBversion object if exist <br/>
+     * Accepts formats 'vX.X.X' and 'X.X.X'
+     * @param version string representation
+     * @return the version Enum object
+     */
+    public static OBVersion fromString(String version) {
+        try {
+            if (!StringUtils.isEmpty(version)) {
+                if (!version.startsWith("v")) {
+                    version = "v".concat(version);
+                }
+                return OBVersion.valueOf(
+                        version.replace(".", "_")
+                                .toLowerCase()
+                );
+            }
+        } catch (IllegalArgumentException e) {
+            log.debug("No match found for {} in enum: {}", version, OBVersion.class.getName(), e);
+        }
+        return null;
+    }
+
+    public boolean isBeforeVersion(OBVersion version) {
+        return this.ordinal() < version.ordinal();
+    }
+
+    public boolean isAfterVersion(OBVersion version) {
+        return this.ordinal() > version.ordinal();
+    }
+
+    /**
+     * Provides the canonical value of version stripping 'v' and replacing '_' for '.'
+     * @return canonical string version formatted to x.x.x
+     */
+    public String getCanonicalVersion() {
+        return this.name().substring(1).replace("_", ".");
+    }
+
+    /**
+     * Provides the canonical Enum name replacing '_' for '.'
+     * @return canonical Enum name formatted to vX.X.X
+     */
+    public String getCanonicalName() {
+        return this.name().replace("_", ".");
+    }
+
+}

--- a/securebanking-openbanking-uk-error/pom.xml
+++ b/securebanking-openbanking-uk-error/pom.xml
@@ -70,4 +70,24 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <!-- Need to format and then check the license as when regenerated the new files will not have the
+                license headers in -->
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>format</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/securebanking-openbanking-uk-forgerock-datamodel/pom.xml
+++ b/securebanking-openbanking-uk-forgerock-datamodel/pom.xml
@@ -75,4 +75,35 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <!-- Need to format and then check the license as when regenerated the new files will not have the
+                license headers in -->
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>format</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/payment/FRFundsConfirmationResponse.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/payment/FRFundsConfirmationResponse.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+/**
+ * Response indicating if funds are available for an account.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FRFundsConfirmationResponse {
+
+    private String accountId;
+    private boolean isFundsAvailable;
+    private DateTime fundsAvailableDateTime;
+}

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRAccountIdentifierTestDataFactory.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRAccountIdentifierTestDataFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.testsupport;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRAccountIdentifier;
+
+/**
+ * Test data factory for {@link FRAccountIdentifier}.
+ */
+public class FRAccountIdentifierTestDataFactory {
+
+    public static FRAccountIdentifier aValidFRAccountIdentifier() {
+        return FRAccountIdentifier.builder()
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("40400411290112")
+                .name("Mr A Jones")
+                .build();
+    }
+
+    public static FRAccountIdentifier aValidFRAccountIdentifier2() {
+        return FRAccountIdentifier.builder()
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("40400422390112")
+                .name("Mrs B Smith")
+                .build();
+    }
+}

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRAmountTestDataFactory.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRAmountTestDataFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.testsupport;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRAmount;
+
+/**
+ * Test data factory for {@link FRAmount}.
+ */
+public class FRAmountTestDataFactory {
+
+    /**
+     * @return a valid instance of {@link FRAmount}
+     */
+    public static FRAmount aValidFRAmount() {
+        return aValidFRAmountBuilder().build();
+    }
+
+    /**
+     * @return an instance of {@link FRAmount.FRAmountBuilder} with the required values populated.
+     */
+    public static FRAmount.FRAmountBuilder aValidFRAmountBuilder() {
+        return FRAmount.builder()
+                .currency("GBP")
+                .amount("10.00");
+    }
+}

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRCashBalanceTestDataFactory.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRCashBalanceTestDataFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.testsupport;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRCashBalance;
+import org.joda.time.DateTime;
+
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRBalanceType.INTERIMAVAILABLE;
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRCreditDebitIndicator.CREDIT;
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.testsupport.FRAmountTestDataFactory.aValidFRAmount;
+
+/**
+ * Test data factory for {@link FRCashBalance}.
+ */
+public class FRCashBalanceTestDataFactory {
+
+    /**
+     * @return a valid instance of {@link FRCashBalance}
+     */
+    public static FRCashBalance aValidFRCashBalance() {
+        return aValidFRCashBalanceBuilder()
+                .build();
+    }
+
+    /**
+     * @return an instance of {@link FRCashBalance.FRCashBalanceBuilder} with the required values populated.
+     */
+    public static FRCashBalance.FRCashBalanceBuilder aValidFRCashBalanceBuilder() {
+        return FRCashBalance.builder()
+                .accountId("12345")
+                .creditDebitIndicator(CREDIT)
+                .type(INTERIMAVAILABLE)
+                .dateTime(DateTime.now())
+                .amount(aValidFRAmount());
+    }
+}

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRFinancialAccountTestDataFactory.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/test/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/testsupport/FRFinancialAccountTestDataFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.testsupport;
+
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountServicer;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount;
+import org.joda.time.DateTime;
+
+import java.util.List;
+
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount.FRAccountStatusCode.ENABLED;
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount.FRAccountSubTypeCode.CURRENTACCOUNT;
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount.FRAccountTypeCode.PERSONAL;
+import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.testsupport.FRAccountIdentifierTestDataFactory.aValidFRAccountIdentifier;
+
+/**
+ * Test data factory for {@link FRFinancialAccount}.
+ */
+public class FRFinancialAccountTestDataFactory {
+
+    public static FRFinancialAccount aValidFRFinancialAccount() {
+        return FRFinancialAccount.builder()
+                .accountId("1234")
+                .status(ENABLED)
+                .statusUpdateDateTime(DateTime.now())
+                .currency("GBP")
+                .accountType(PERSONAL)
+                .accountSubType(CURRENTACCOUNT)
+                .description("A personal current account")
+                .nickname("House Account")
+                .openingDate(DateTime.now().minusDays(1))
+                .maturityDate(null)
+                .accounts(List.of(aValidFRAccountIdentifier()))
+                .servicer(FRAccountServicer.builder()
+                        .schemeName("UK.OBIE.SortCodeAccountNumber")
+                        .identification("9876")
+                        .build())
+                .build();
+    }
+
+}


### PR DESCRIPTION
### 33 - Added  FRFundsConfirmationResponse and test data factories

- Added FRFundsConfirmationResponse for bank simulator's backoffice API
- Added test data factories for FR data objects
- Added OBVersion
- Added licence check plugin to missing modules

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/33