### PR TITLE
62 JSON fixes for the RCS UI

### DIFF
--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRBalanceType.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRBalanceType.java
@@ -15,6 +15,9 @@
  */
 package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.stream.Stream;
 
 public enum FRBalanceType {
@@ -42,10 +45,12 @@ public enum FRBalanceType {
         return value;
     }
 
+    @JsonValue
     public String toString() {
         return value;
     }
 
+    @JsonCreator
     public static FRBalanceType fromValue(String value) {
         return Stream.of(values())
                 .filter(type -> type.getValue().equals(value))

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRCreditDebitIndicator.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRCreditDebitIndicator.java
@@ -15,6 +15,9 @@
  */
 package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.stream.Stream;
 
 public enum FRCreditDebitIndicator {
@@ -31,10 +34,12 @@ public enum FRCreditDebitIndicator {
         return value;
     }
 
+    @JsonValue
     public String toString() {
         return value;
     }
 
+    @JsonCreator
     public static FRCreditDebitIndicator fromValue(String value) {
         return Stream.of(values())
                 .filter(type -> type.getValue().equals(value))

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRCreditLine.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRCreditLine.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRAmount;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,10 +61,12 @@ public class FRCreditLine {
             return value;
         }
 
+        @JsonValue
         public String toString() {
             return value;
         }
 
+        @JsonCreator
         public static FRLimitType fromValue(String value) {
             return Stream.of(values())
                     .filter(type -> type.getValue().equals(value))

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRFinancialAccount.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRFinancialAccount.java
@@ -15,6 +15,8 @@
  */
 package com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRAccountIdentifier;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +41,6 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 @Builder
 public class FRFinancialAccount {
-
     private String accountId;
     private FRAccountStatusCode status;
     private DateTime statusUpdateDateTime;
@@ -70,10 +71,12 @@ public class FRFinancialAccount {
             return value;
         }
 
+        @JsonValue
         public String toString() {
             return value;
         }
 
+        @JsonCreator
         public static FRAccountStatusCode fromValue(String value) {
             return Stream.of(values())
                     .filter(type -> type.getValue().equals(value))
@@ -96,10 +99,12 @@ public class FRFinancialAccount {
             return value;
         }
 
+        @JsonValue
         public String toString() {
             return value;
         }
 
+        @JsonCreator
         public static FRAccountTypeCode fromValue(String value) {
             return Stream.of(values())
                     .filter(type -> type.getValue().equals(value))
@@ -128,10 +133,12 @@ public class FRFinancialAccount {
             return value;
         }
 
+        @JsonValue
         public String toString() {
             return value;
         }
 
+        @JsonCreator
         public static FRAccountSubTypeCode fromValue(String value) {
             return Stream.of(values())
                     .filter(type -> type.getValue().equals(value))

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/payment/FRAccountIdentifier.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/payment/FRAccountIdentifier.java
@@ -34,9 +34,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class FRAccountIdentifier {
-
     private String schemeName;
     private String identification;
     private String name;
     private String secondaryIdentification;
+
 }


### PR DESCRIPTION
Rather than using the unconventional format that the OB objects use (e.g. `AccountId` rather than `accountId`), this PR switches back to the standard `accountId` type format. Some minor modifications have been made to the securebanking RCS UI to accommodate this format.

Additionally, some `@JsonCreator` and `@JsonValue` properties were missing on some of the enuns.

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/62